### PR TITLE
Introduce purs-tidy formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Set up a PureScript toolchain
         uses: purescript-contrib/setup-purescript@main
+        with:
+          purs-tidy: "latest"
 
       - name: Cache PureScript dependencies
         uses: actions/cache@v2
@@ -32,3 +34,6 @@ jobs:
 
       - name: Run tests
         run: spago test --no-install
+
+      - name: Check formatting
+        run: purs-tidy check src test

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !.gitignore
 !.github
 !.editorconfig
+!.tidyrc.json
 
 output
 generated-docs

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "source",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "never",
+  "width": null
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Added `purs-tidy` formatter (#25 by @thomashoneyman)
 - Updated dependencies to clear build errors related to unlisted dependencies (#24 by @flounders)
 
 ## [v0.5.0](https://github.com/purescript-contrib/purescript-matryoshka/releases/tag/v0.5.0) - 2021-02-26

--- a/src/Matryoshka/Algebra.purs
+++ b/src/Matryoshka/Algebra.purs
@@ -17,15 +17,15 @@ limitations under the License.
 module Matryoshka.Algebra where
 
 type GAlgebra :: (Type -> Type) -> (Type -> Type) -> Type -> Type
-type GAlgebra w f a = f (w a) → a
+type GAlgebra w f a = f (w a) -> a
 
 type GAlgebraM :: (Type -> Type) -> (Type -> Type) -> (Type -> Type) -> Type -> Type
-type GAlgebraM w m f a = f (w a) → m a
+type GAlgebraM w m f a = f (w a) -> m a
 
-type Algebra f a = f a → a
+type Algebra f a = f a -> a
 
 type AlgebraM :: (Type -> Type) -> (Type -> Type) -> Type -> Type
-type AlgebraM m f a = f a → m a
+type AlgebraM m f a = f a -> m a
 
 type ElgotAlgebra :: (Type -> Type) -> (Type -> Type) -> Type -> Type
-type ElgotAlgebra w f a = w (f a) → a
+type ElgotAlgebra w f a = w (f a) -> a

--- a/src/Matryoshka/Class/Corecursive.purs
+++ b/src/Matryoshka/Class/Corecursive.purs
@@ -29,19 +29,19 @@ import Data.Tuple (Tuple(..))
 
 import Matryoshka.Pattern.CoEnvT (CoEnvT(..))
 
-class Functor f ⇐ Corecursive t f | t → f where
-  embed ∷ f t → t
+class Functor f <= Corecursive t f | t -> f where
+  embed :: f t -> t
 
-instance corecursiveMu ∷ Functor f ⇒ Corecursive (Mu f) f where
+instance corecursiveMu :: Functor f => Corecursive (Mu f) f where
   embed = roll
 
-instance corecursiveNu ∷ Functor f ⇒ Corecursive (Nu f) f where
+instance corecursiveNu :: Functor f => Corecursive (Nu f) f where
   embed = flip unfold (map observe)
 
-instance corecursiveFree ∷ Functor f ⇒ Corecursive (Free f a) (CoEnvT a f) where
+instance corecursiveFree :: Functor f => Corecursive (Free f a) (CoEnvT a f) where
   embed (CoEnvT e) = either pure (join <<< liftF) e
 
-instance corecursiveCofree ∷ Functor f ⇒ Corecursive (Cofree f a) (EnvT a f) where
+instance corecursiveCofree :: Functor f => Corecursive (Cofree f a) (EnvT a f) where
   embed et = mkCofree (ask et) (lower et)
     where
     ask (EnvT (Tuple e _)) = e

--- a/src/Matryoshka/Class/Recursive.purs
+++ b/src/Matryoshka/Class/Recursive.purs
@@ -29,17 +29,17 @@ import Data.Tuple (Tuple(..))
 
 import Matryoshka.Pattern.CoEnvT (CoEnvT(..))
 
-class Functor f ⇐ Recursive t f | t → f where
-  project ∷ t → f t
+class Functor f <= Recursive t f | t -> f where
+  project :: t -> f t
 
-instance recursiveMu ∷ Functor f ⇒ Recursive (Mu f) f where
+instance recursiveMu :: Functor f => Recursive (Mu f) f where
   project = unroll
 
-instance recursiveNu ∷ Functor f ⇒ Recursive (Nu f) f where
+instance recursiveNu :: Functor f => Recursive (Nu f) f where
   project = observe
 
-instance recursiveFree ∷ Functor f ⇒ Recursive (Free f a) (CoEnvT a f) where
+instance recursiveFree :: Functor f => Recursive (Free f a) (CoEnvT a f) where
   project = CoEnvT <<< either Right Left <<< resume
 
-instance recursiveCofree ∷ Functor f ⇒ Recursive (Cofree f a) (EnvT a f) where
+instance recursiveCofree :: Functor f => Recursive (Cofree f a) (EnvT a f) where
   project cf = EnvT $ Tuple (head cf) (tail cf)

--- a/src/Matryoshka/Coalgebra.purs
+++ b/src/Matryoshka/Coalgebra.purs
@@ -17,15 +17,15 @@ limitations under the License.
 module Matryoshka.Coalgebra where
 
 type GCoalgebra :: (Type -> Type) -> (Type -> Type) -> Type -> Type
-type GCoalgebra n f a = a → f (n a)
+type GCoalgebra n f a = a -> f (n a)
 
 type GCoalgebraM :: (Type -> Type) -> (Type -> Type) -> (Type -> Type) -> Type -> Type
-type GCoalgebraM n m f a = a → m (f (n a))
+type GCoalgebraM n m f a = a -> m (f (n a))
 
-type Coalgebra f a = a → f a
+type Coalgebra f a = a -> f a
 
 type CoalgebraM :: (Type -> Type) -> (Type -> Type) -> Type -> Type
-type CoalgebraM m f a = a → m (f a)
+type CoalgebraM m f a = a -> m (f a)
 
 type ElgotCoalgebra :: (Type -> Type) -> (Type -> Type) -> Type -> Type
-type ElgotCoalgebra e f a = a → e (f a)
+type ElgotCoalgebra e f a = a -> e (f a)

--- a/src/Matryoshka/DistributiveLaw.purs
+++ b/src/Matryoshka/DistributiveLaw.purs
@@ -37,79 +37,79 @@ import Matryoshka.Class.Corecursive (class Corecursive, embed)
 import Matryoshka.Class.Recursive (class Recursive, project)
 import Matryoshka.Coalgebra (Coalgebra)
 
-type DistributiveLaw f g = ∀ a. f (g a) → g (f a)
+type DistributiveLaw f g = forall a. f (g a) -> g (f a)
 
-distApplicative ∷ ∀ f g. Traversable f ⇒ Applicative g ⇒ DistributiveLaw f g
+distApplicative :: forall f g. Traversable f => Applicative g => DistributiveLaw f g
 distApplicative = sequence
 
-distDistributive ∷ ∀ f g. Traversable f ⇒ Distributive g ⇒ DistributiveLaw f g
+distDistributive :: forall f g. Traversable f => Distributive g => DistributiveLaw f g
 distDistributive = distribute
 
-distCata ∷ ∀ f. Functor f ⇒ DistributiveLaw f Identity
+distCata :: forall f. Functor f => DistributiveLaw f Identity
 distCata = wrap <<< map unwrap
 
-distPara ∷ ∀ t f. Corecursive t f ⇒ DistributiveLaw f (Tuple t)
+distPara :: forall t f. Corecursive t f => DistributiveLaw f (Tuple t)
 distPara = distZygo embed
 
 distParaT
-  ∷ ∀ t f w
-  . Corecursive t f
-  ⇒ Comonad w
-  ⇒ DistributiveLaw f w
-  → DistributiveLaw f (EnvT t w)
+  :: forall t f w
+   . Corecursive t f
+  => Comonad w
+  => DistributiveLaw f w
+  -> DistributiveLaw f (EnvT t w)
 distParaT = distZygoT embed
 
-distZygo ∷ ∀ f a. Functor f ⇒ Algebra f a → DistributiveLaw f (Tuple a)
+distZygo :: forall f a. Functor f => Algebra f a -> DistributiveLaw f (Tuple a)
 distZygo g m = Tuple (g (map fst m)) (map snd m)
 
 distZygoT
-  ∷ ∀ f w a
-  . Functor f
-  ⇒ Comonad w
-  ⇒ Algebra f a
-  → DistributiveLaw f w
-  → DistributiveLaw f (EnvT a w)
+  :: forall f w a
+   . Functor f
+  => Comonad w
+  => Algebra f a
+  -> DistributiveLaw f w
+  -> DistributiveLaw f (EnvT a w)
 distZygoT g k fe =
   EnvT $ Tuple (g (fst <<< runEnvT <$> fe)) (k (lower <$> fe))
 
-distHisto ∷ ∀ f. Functor f ⇒ DistributiveLaw f (Cofree f)
+distHisto :: forall f. Functor f => DistributiveLaw f (Cofree f)
 distHisto = distGHisto identity
 
 distGHisto
-  ∷ ∀ f h
-  . Functor f
-  ⇒ Functor h
-  ⇒ DistributiveLaw f h
-  → DistributiveLaw f (Cofree h)
+  :: forall f h
+   . Functor f
+  => Functor h
+  => DistributiveLaw f h
+  -> DistributiveLaw f (Cofree h)
 distGHisto k = unfoldCofree (map extract) (k <<< map tail)
 
-distAna ∷ ∀ f. Functor f ⇒ DistributiveLaw Identity f
+distAna :: forall f. Functor f => DistributiveLaw Identity f
 distAna = map wrap <<< unwrap
 
-distApo ∷ ∀ t f. Recursive t f ⇒ DistributiveLaw (Either t) f
+distApo :: forall t f. Recursive t f => DistributiveLaw (Either t) f
 distApo = distGApo project
 
-distGApo ∷ ∀ f a. Functor f ⇒ Coalgebra f a → DistributiveLaw (Either a) f
+distGApo :: forall f a. Functor f => Coalgebra f a -> DistributiveLaw (Either a) f
 distGApo f = either (map Left <<< f) (map Right)
 
 distGApoT
-  ∷ ∀ f m a
-  . Functor f
-  ⇒ Functor m
-  ⇒ Coalgebra f a
-  → DistributiveLaw m f
-  → DistributiveLaw (ExceptT a m) f
+  :: forall f m a
+   . Functor f
+  => Functor m
+  => Coalgebra f a
+  -> DistributiveLaw m f
+  -> DistributiveLaw (ExceptT a m) f
 distGApoT g k = map ExceptT <<< k <<< map (distGApo g) <<< runExceptT
 
-distFutu ∷ ∀ f. Functor f ⇒ DistributiveLaw (Free f) f
+distFutu :: forall f. Functor f => DistributiveLaw (Free f) f
 distFutu = distGFutu identity
 
 distGFutu
-  ∷ ∀ f h
-  . Functor f
-  ⇒ Functor h
-  ⇒ DistributiveLaw h f
-  → DistributiveLaw (Free h) f
+  :: forall f h
+   . Functor f
+  => Functor h
+  => DistributiveLaw h f
+  -> DistributiveLaw (Free h) f
 distGFutu k f = case resume f of
-  Left as → join <<< liftF <$> k (distGFutu k <$> as)
-  Right b → pure <$> b
+  Left as -> join <<< liftF <$> k (distGFutu k <$> as)
+  Right b -> pure <$> b

--- a/src/Matryoshka/Fold.purs
+++ b/src/Matryoshka/Fold.purs
@@ -37,346 +37,350 @@ import Matryoshka.DistributiveLaw (DistributiveLaw, distGHisto, distHisto, distZ
 import Matryoshka.Util (mapR, traverseR)
 import Matryoshka.Transform (AlgebraicGTransform, Transform, TransformM)
 
-cata ∷ ∀ t f a. Recursive t f ⇒ Algebra f a → t → a
+cata :: forall t f a. Recursive t f => Algebra f a -> t -> a
 cata f = go
   where
   go t = f $ map go $ project t
 
 cataM
-  ∷ ∀ t f m a
-  . Recursive t f
-  ⇒ Monad m
-  ⇒ Traversable f
-  ⇒ AlgebraM m f a
-  → t
-  → m a
+  :: forall t f m a
+   . Recursive t f
+  => Monad m
+  => Traversable f
+  => AlgebraM m f a
+  -> t
+  -> m a
 cataM f = go
   where
   go t = f =<< traverse go (project t)
 
 gcata
-  ∷ ∀ t f w a
-  . Recursive t f
-  ⇒ Comonad w
-  ⇒ DistributiveLaw f w
-  → GAlgebra w f a
-  → t
-  → a
+  :: forall t f w a
+   . Recursive t f
+  => Comonad w
+  => DistributiveLaw f w
+  -> GAlgebra w f a
+  -> t
+  -> a
 gcata k g = g <<< extract <<< go
   where
   go t = k $ map (duplicate <<< map g <<< go) (project t)
 
 gcataM
-  ∷ ∀ t f w m a
-  . Recursive t f
-  ⇒ Monad m
-  ⇒ Comonad w
-  ⇒ Traversable f
-  ⇒ Traversable w
-  ⇒ DistributiveLaw f w
-  → GAlgebraM w m f a
-  → t
-  → m a
+  :: forall t f w m a
+   . Recursive t f
+  => Monad m
+  => Comonad w
+  => Traversable f
+  => Traversable w
+  => DistributiveLaw f w
+  -> GAlgebraM w m f a
+  -> t
+  -> m a
 gcataM k g = g <<< extract <=< loop
   where
   loop t = k <$> traverse (map duplicate <<< traverse g <=< loop) (project t)
 
 elgotCata
-  ∷ ∀ t f w a
-  . Recursive t f
-  ⇒ Comonad w
-  ⇒ DistributiveLaw f w
-  → ElgotAlgebra w f a
-  → t
-  → a
+  :: forall t f w a
+   . Recursive t f
+  => Comonad w
+  => DistributiveLaw f w
+  -> ElgotAlgebra w f a
+  -> t
+  -> a
 elgotCata k g = g <<< go
   where
   go t = k $ map (map g <<< duplicate <<< go) (project t)
 
 transCata
-  ∷ ∀ t f u g
-  . Recursive t f
-  ⇒ Corecursive u g
-  ⇒ Transform u f g
-  → t
-  → u
+  :: forall t f u g
+   . Recursive t f
+  => Corecursive u g
+  => Transform u f g
+  -> t
+  -> u
 transCata f = go
   where
   go t = mapR (f <<< map go) t
 
 transCataT
-  ∷ ∀ t f
-  . Recursive t f
-  ⇒ Corecursive t f
-  ⇒ (t → t)
-  → t
-  → t
+  :: forall t f
+   . Recursive t f
+  => Corecursive t f
+  => (t -> t)
+  -> t
+  -> t
 transCataT f = go
   where
   go t = f $ mapR (map go) t
 
 transCataM
-  ∷ ∀ t f u g m
-  . Recursive t f
-  ⇒ Corecursive u g
-  ⇒ Monad m
-  ⇒ Traversable f
-  ⇒ TransformM m u f g
-  → t
-  → m u
+  :: forall t f u g m
+   . Recursive t f
+  => Corecursive u g
+  => Monad m
+  => Traversable f
+  => TransformM m u f g
+  -> t
+  -> m u
 transCataM f = go
   where
   go t = traverseR (f <=< traverse go) t
 
 transCataTM
-  ∷ ∀ t f m
-  . Recursive t f
-  ⇒ Corecursive t f
-  ⇒ Monad m
-  ⇒ Traversable f
-  ⇒ (t → m t)
-  → t
-  → m t
+  :: forall t f m
+   . Recursive t f
+  => Corecursive t f
+  => Monad m
+  => Traversable f
+  => (t -> m t)
+  -> t
+  -> m t
 transCataTM f = go
   where
   go t = f =<< traverseR (traverse go) t
 
 topDownCata
-  ∷ ∀ t f a
-  . Recursive t f
-  ⇒ Corecursive t f
-  ⇒ (a → t → Tuple a t)
-  → a
-  → t
-  → t
+  :: forall t f a
+   . Recursive t f
+  => Corecursive t f
+  => (a -> t -> Tuple a t)
+  -> a
+  -> t
+  -> t
 topDownCata f = go
   where
   go a t = case f a t of
-    Tuple a' tf → mapR (map (go a')) tf
+    Tuple a' tf -> mapR (map (go a')) tf
 
 topDownCataM
-  ∷ ∀ t f m a
-  . Recursive t f
-  ⇒ Corecursive t f
-  ⇒ Monad m
-  ⇒ Traversable f
-  ⇒ (a → t → m (Tuple a t))
-  → a
-  → t
-  → m t
+  :: forall t f m a
+   . Recursive t f
+  => Corecursive t f
+  => Monad m
+  => Traversable f
+  => (a -> t -> m (Tuple a t))
+  -> a
+  -> t
+  -> m t
 topDownCataM f = go
   where
   go a t = f a t >>= case _ of
-    Tuple a' tf → traverseR (traverse (go a')) tf
+    Tuple a' tf -> traverseR (traverse (go a')) tf
 
 prepro
-  ∷ ∀ t f a
-  . Recursive t f
-  ⇒ Corecursive t f
-  ⇒ (f ~> f)
-  → Algebra f a
-  → t
-  → a
+  :: forall t f a
+   . Recursive t f
+  => Corecursive t f
+  => (f ~> f)
+  -> Algebra f a
+  -> t
+  -> a
 prepro f g = go
   where
   go t = g $ (go <<< cata (embed <<< f)) <$> project t
 
 gprepro
-  ∷ ∀ t f w a
-  . Recursive t f
-  ⇒ Corecursive t f
-  ⇒ Comonad w
-  ⇒ DistributiveLaw f w
-  → (f ~> f)
-  → GAlgebra w f a
-  → t
-  → a
+  :: forall t f w a
+   . Recursive t f
+  => Corecursive t f
+  => Comonad w
+  => DistributiveLaw f w
+  -> (f ~> f)
+  -> GAlgebra w f a
+  -> t
+  -> a
 gprepro f g h = extract <<< go
   where
   go t = h <$> f (duplicate <<< go <<< cata (embed <<< g) <$> project t)
 
 transPrepro
-  ∷ ∀ t f u g
-  . Recursive t f
-  ⇒ Corecursive t f
-  ⇒ Corecursive u g
-  ⇒ (f ~> f)
-  → Transform u f g
-  → t
-  → u
+  :: forall t f u g
+   . Recursive t f
+  => Corecursive t f
+  => Corecursive u g
+  => (f ~> f)
+  -> Transform u f g
+  -> t
+  -> u
 transPrepro f g = go
   where
   go t = mapR (g <<< map (go <<< transCata f)) t
 
-para ∷ ∀ t f a. Recursive t f ⇒ GAlgebra (Tuple t) f a → t → a
+para :: forall t f a. Recursive t f => GAlgebra (Tuple t) f a -> t -> a
 para f = go
   where
   go t = f (g <$> project t)
   g t = Tuple t (go t)
 
 paraM
-  ∷ ∀ t f m a
-  . Recursive t f
-  ⇒ Monad m
-  ⇒ Traversable f
-  ⇒ GAlgebraM (Tuple t) m f a
-  → t
-  → m a
+  :: forall t f m a
+   . Recursive t f
+  => Monad m
+  => Traversable f
+  => GAlgebraM (Tuple t) m f a
+  -> t
+  -> m a
 paraM f = go
   where
   go t = f =<< traverse (map (Tuple t) <<< go) (project t)
 
 gpara
-  ∷ ∀ t f w a
-  . Recursive t f
-  ⇒ Corecursive t f
-  ⇒ Comonad w
-  ⇒ DistributiveLaw f w
-  → GAlgebra (EnvT t w) f a
-  → t
-  → a
+  :: forall t f w a
+   . Recursive t f
+  => Corecursive t f
+  => Comonad w
+  => DistributiveLaw f w
+  -> GAlgebra (EnvT t w) f a
+  -> t
+  -> a
 gpara = gzygo embed
 
-elgotPara ∷ ∀ t f a. Recursive t f ⇒ ElgotAlgebra (Tuple t) f a → t → a
+elgotPara :: forall t f a. Recursive t f => ElgotAlgebra (Tuple t) f a -> t -> a
 elgotPara f = go
   where
   go t = f (Tuple t (go <$> project t))
 
 transPara
-  ∷ ∀ t f u g
-  . Recursive t f
-  ⇒ Corecursive u g
-  ⇒ AlgebraicGTransform (Tuple t) u f g
-  → t
-  → u
+  :: forall t f u g
+   . Recursive t f
+  => Corecursive u g
+  => AlgebraicGTransform (Tuple t) u f g
+  -> t
+  -> u
 transPara f = go
   where
   go t = mapR (f <<< map (identity &&& go)) t
 
 transParaT
-  ∷ ∀ t f
-  . Recursive t f
-  ⇒ Corecursive t f
-  ⇒ (t → t → t)
-  → t
-  → t
+  :: forall t f
+   . Recursive t f
+  => Corecursive t f
+  => (t -> t -> t)
+  -> t
+  -> t
 transParaT f = go
   where
   go t = f t (mapR (map go) t)
 
 zygo
-  ∷ ∀ t f a b
-  . Recursive t f
-  ⇒ Algebra f b
-  → GAlgebra (Tuple b) f a
-  → t
-  → a
+  :: forall t f a b
+   . Recursive t f
+  => Algebra f b
+  -> GAlgebra (Tuple b) f a
+  -> t
+  -> a
 zygo = gcata <<< distZygo
 
 gzygo
-  ∷ ∀ t f w a b
-  . Recursive t f
-  ⇒ Comonad w
-  ⇒ Algebra f b
-  → DistributiveLaw f w
-  → GAlgebra (EnvT b w) f a
-  → t
-  → a
+  :: forall t f w a b
+   . Recursive t f
+  => Comonad w
+  => Algebra f b
+  -> DistributiveLaw f w
+  -> GAlgebra (EnvT b w) f a
+  -> t
+  -> a
 gzygo f w = gcata (distZygoT f w)
 
 elgotZygo
-  ∷ ∀ t f a b
-  . Recursive t f
-  ⇒ Algebra f b
-  → ElgotAlgebra (Tuple b) f a
-  → t
-  → a
+  :: forall t f a b
+   . Recursive t f
+  => Algebra f b
+  -> ElgotAlgebra (Tuple b) f a
+  -> t
+  -> a
 elgotZygo = elgotCata <<< distZygo
 
 gElgotZygo
-  ∷ ∀ t f w a b
-  . Recursive t f
-  ⇒ Comonad w
-  ⇒ Algebra f b
-  → DistributiveLaw f w
-  → ElgotAlgebra (EnvT b w) f a
-  → t
-  → a
+  :: forall t f w a b
+   . Recursive t f
+  => Comonad w
+  => Algebra f b
+  -> DistributiveLaw f w
+  -> ElgotAlgebra (EnvT b w) f a
+  -> t
+  -> a
 gElgotZygo f w = elgotCata (distZygoT f w)
 
 mutu
-  ∷ ∀ t f a b
-  . Recursive t f
-  ⇒ GAlgebra (Tuple a) f b
-  → GAlgebra (Tuple b) f a
-  → t
-  → a
+  :: forall t f a b
+   . Recursive t f
+  => GAlgebra (Tuple a) f b
+  -> GAlgebra (Tuple b) f a
+  -> t
+  -> a
 mutu f g = g <<< map go <<< project
   where
   go x = Tuple (mutu g f x) (mutu f g x)
 
 histo
-  ∷ ∀ t f a
-  . Recursive t f
-  ⇒ GAlgebra (Cofree f) f a
-  → t
-  → a
+  :: forall t f a
+   . Recursive t f
+  => GAlgebra (Cofree f) f a
+  -> t
+  -> a
 histo = gcata distHisto
 
 ghisto
-  ∷ ∀ t f h a
-  . Recursive t f
-  ⇒ Functor h
-  ⇒ DistributiveLaw f h
-  → GAlgebra (Cofree h) f a
-  → t
-  → a
+  :: forall t f h a
+   . Recursive t f
+  => Functor h
+  => DistributiveLaw f h
+  -> GAlgebra (Cofree h) f a
+  -> t
+  -> a
 ghisto g = gcata (distGHisto g)
 
 elgotHisto
-  ∷ ∀ t f a
-  . Recursive t f
-  ⇒ ElgotAlgebra (Cofree f) f a
-  → t
-  → a
+  :: forall t f a
+   . Recursive t f
+  => ElgotAlgebra (Cofree f) f a
+  -> t
+  -> a
 elgotHisto = elgotCata distHisto
 
 annotateTopDown
-  ∷ ∀ t f a
-  . Recursive t f
-  ⇒ (a → f t → a)
-  → a
-  → t
-  → Cofree f a
+  :: forall t f a
+   . Recursive t f
+  => (a -> f t -> a)
+  -> a
+  -> t
+  -> Cofree f a
 annotateTopDown f z = go
   where
   go t =
-    let ft = project t
-    in mkCofree (f z ft) (map go ft)
+    let
+      ft = project t
+    in
+      mkCofree (f z ft) (map go ft)
 
 annotateTopDownM
-  ∷ ∀ t f m a
-  . Recursive t f
-  ⇒ Monad m
-  ⇒ Traversable f
-  ⇒ (a → f t → m a)
-  → a
-  → t
-  → m (Cofree f a)
+  :: forall t f m a
+   . Recursive t f
+  => Monad m
+  => Traversable f
+  => (a -> f t -> m a)
+  -> a
+  -> t
+  -> m (Cofree f a)
 annotateTopDownM f z = go
   where
   go t =
-    let ft = project t
-    in (flip map (traverse go ft) <<< mkCofree) =<< f z ft
+    let
+      ft = project t
+    in
+      (flip map (traverse go ft) <<< mkCofree) =<< f z ft
 
-isLeaf ∷ ∀ t f. Recursive t f ⇒ Foldable f ⇒ t → Boolean
+isLeaf :: forall t f. Recursive t f => Foldable f => t -> Boolean
 isLeaf t = alaF Disj foldMap (const true) (project t)
 
-children ∷ ∀ t f. Recursive t f ⇒ Foldable f ⇒ t → List t
+children :: forall t f. Recursive t f => Foldable f => t -> List t
 children = foldMap pure <<< project
 
-universe ∷ ∀ t f. Recursive t f ⇒ Foldable f ⇒ t → List t
+universe :: forall t f. Recursive t f => Foldable f => t -> List t
 universe t = universe =<< children t
 
-lambek ∷ ∀ t f. Recursive t f ⇒ Corecursive t f ⇒ t → f t
+lambek :: forall t f. Recursive t f => Corecursive t f => t -> f t
 lambek = cata (map embed)

--- a/src/Matryoshka/Pattern/CoEnvT.purs
+++ b/src/Matryoshka/Pattern/CoEnvT.purs
@@ -28,16 +28,16 @@ import Data.Bifunctor (lmap)
 newtype CoEnvT :: Type -> (Type -> Type) -> Type -> Type
 newtype CoEnvT e m a = CoEnvT (Either e (m a))
 
-runEnvT ∷ ∀ e m a. CoEnvT e m a → Either e (m a)
+runEnvT :: forall e m a. CoEnvT e m a -> Either e (m a)
 runEnvT (CoEnvT x) = x
 
-withEnvT ∷ ∀ e1 e2 m a. (e1 → e2) → CoEnvT e1 m a → CoEnvT e2 m a
+withEnvT :: forall e1 e2 m a. (e1 -> e2) -> CoEnvT e1 m a -> CoEnvT e2 m a
 withEnvT f (CoEnvT e) = CoEnvT (lmap f e)
 
-mapEnvT ∷ ∀ e m1 m2 a b. (m1 a → m2 b) → CoEnvT e m1 a → CoEnvT e m2 b
+mapEnvT :: forall e m1 m2 a b. (m1 a -> m2 b) -> CoEnvT e m1 a -> CoEnvT e m2 b
 mapEnvT f (CoEnvT e) = CoEnvT (map f e)
 
-derive instance newtypeEnvT ∷ Newtype (CoEnvT e m a) _
+derive instance newtypeEnvT :: Newtype (CoEnvT e m a) _
 
-instance functorEnvT ∷ Functor m ⇒ Functor (CoEnvT e m) where
+instance functorEnvT :: Functor m => Functor (CoEnvT e m) where
   map f (CoEnvT e) = CoEnvT (map (map f) e)

--- a/src/Matryoshka/Refold.purs
+++ b/src/Matryoshka/Refold.purs
@@ -37,110 +37,110 @@ import Matryoshka.Transform (Transform)
 import Matryoshka.Util (mapR)
 
 hylo
-  ∷ ∀ f a b
-  . Functor f
-  ⇒ Algebra f b
-  → Coalgebra f a
-  → a
-  → b
+  :: forall f a b
+   . Functor f
+  => Algebra f b
+  -> Coalgebra f a
+  -> a
+  -> b
 hylo f g = go
   where
   go a = f $ go <$> g a
 
 hyloM
-  ∷ ∀ f m a b
-  . Monad m
-  ⇒ Traversable f
-  ⇒ AlgebraM m f b
-  → CoalgebraM m f a
-  → a
-  → m b
+  :: forall f m a b
+   . Monad m
+  => Traversable f
+  => AlgebraM m f b
+  -> CoalgebraM m f a
+  -> a
+  -> m b
 hyloM f g = go
   where
   go a = f =<< traverse go =<< g a
 
 ghylo
-  ∷ ∀ f w n a b
-  . Monad n
-  ⇒ Comonad w
-  ⇒ Functor f
-  ⇒ DistributiveLaw f w
-  → DistributiveLaw n f
-  → GAlgebra w f b
-  → GCoalgebra n f a
-  → a
-  → b
+  :: forall f w n a b
+   . Monad n
+  => Comonad w
+  => Functor f
+  => DistributiveLaw f w
+  -> DistributiveLaw n f
+  -> GAlgebra w f b
+  -> GCoalgebra n f a
+  -> a
+  -> b
 ghylo w n f g = extract <<< go <<< pure
   where
   go na = f <$> w ((duplicate <<< go <<< join) <$> n (g <$> na))
 
 ghyloM
-  ∷ ∀ f w n m a b
-  . Monad m
-  ⇒ Monad n
-  ⇒ Comonad w
-  ⇒ Traversable f
-  ⇒ Traversable w
-  ⇒ Traversable n
-  ⇒ DistributiveLaw f w
-  → DistributiveLaw n f
-  → GAlgebraM w m f b
-  → GCoalgebraM n m f a
-  → a
-  → m b
+  :: forall f w n m a b
+   . Monad m
+  => Monad n
+  => Comonad w
+  => Traversable f
+  => Traversable w
+  => Traversable n
+  => DistributiveLaw f w
+  -> DistributiveLaw n f
+  -> GAlgebraM w m f b
+  -> GCoalgebraM n m f a
+  -> a
+  -> m b
 ghyloM w m f g = map extract <<< h <<< pure
   where
   h x = traverse f =<< w <$> (traverse (map duplicate <<< h <<< join) <<< m =<< traverse g x)
 
 transHylo
-  ∷ ∀ t f g h u
-  . Recursive t f
-  ⇒ Corecursive u h
-  ⇒ Functor g
-  ⇒ Transform u g h
-  → Transform t f g
-  → t
-  → u
+  :: forall t f g h u
+   . Recursive t f
+  => Corecursive u h
+  => Functor g
+  => Transform u g h
+  -> Transform t f g
+  -> t
+  -> u
 transHylo f g = go
   where
   go t = mapR (f <<< map go <<< g) t
 
 dyna
-  ∷ ∀ f a b
-  . Functor f
-  ⇒ GAlgebra (Cofree f) f b
-  → Coalgebra f a
-  → a
-  → b
+  :: forall f a b
+   . Functor f
+  => GAlgebra (Cofree f) f b
+  -> Coalgebra f a
+  -> a
+  -> b
 dyna f g = ghylo distHisto distAna f (map Identity <<< g)
 
 codyna
-  ∷ ∀ f a b
-  . Functor f
-  ⇒ Algebra f b
-  → GCoalgebra (Free f) f a
-  → a
-  → b
+  :: forall f a b
+   . Functor f
+  => Algebra f b
+  -> GCoalgebra (Free f) f a
+  -> a
+  -> b
 codyna f = ghylo distCata distFutu (lcmap (map unwrap) f)
 
 codynaM
-  ∷ ∀ f m a b
-  . Monad m
-  ⇒ Traversable f
-  ⇒ AlgebraM m f b
-  → GCoalgebraM (Free f) m f a
-  → a
-  → m b
+  :: forall f m a b
+   . Monad m
+  => Traversable f
+  => AlgebraM m f b
+  -> GCoalgebraM (Free f) m f a
+  -> a
+  -> m b
 codynaM f = ghyloM distCata distFutu (lcmap (map unwrap) f)
 
 chrono
-  ∷ ∀ f a b
-  . Functor f
-  ⇒ GAlgebra (Cofree f) f b
-  → GCoalgebra (Free f) f a
-  → a
-  → b
+  :: forall f a b
+   . Functor f
+  => GAlgebra (Cofree f) f b
+  -> GCoalgebra (Free f) f a
+  -> a
+  -> b
 chrono = ghylo distHisto distFutu
 
-convertTo ∷ ∀ t f r. Recursive t f ⇒ Corecursive r f ⇒ t → r
+convertTo :: forall t f r. Recursive t f => Corecursive r f => t -> r
 convertTo = cata embed

--- a/src/Matryoshka/Transform.purs
+++ b/src/Matryoshka/Transform.purs
@@ -17,13 +17,13 @@ limitations under the License.
 module Matryoshka.Transform where
 
 type Transform :: Type -> (Type -> Type) -> (Type -> Type) -> Type
-type Transform t f g = f t → g t
+type Transform t f g = f t -> g t
 
 type TransformM :: (Type -> Type) -> Type -> (Type -> Type) -> (Type -> Type) -> Type
-type TransformM m t f g = f t → m (g t)
+type TransformM m t f g = f t -> m (g t)
 
 type AlgebraicGTransform :: (Type -> Type) -> Type -> (Type -> Type) -> (Type -> Type) -> Type
-type AlgebraicGTransform w t f g = f (w t) → g t
+type AlgebraicGTransform w t f g = f (w t) -> g t
 
 type CoalgebraicGTransform :: (Type -> Type) -> Type -> (Type -> Type) -> (Type -> Type) -> Type
-type CoalgebraicGTransform n t f g = f t → g (n t)
+type CoalgebraicGTransform n t f g = f t -> g (n t)

--- a/src/Matryoshka/Unfold.purs
+++ b/src/Matryoshka/Unfold.purs
@@ -31,215 +31,215 @@ import Matryoshka.DistributiveLaw (DistributiveLaw, distAna, distFutu)
 import Matryoshka.Transform (CoalgebraicGTransform, Transform, TransformM)
 import Matryoshka.Util (mapR, traverseR)
 
-ana ∷ ∀ t f a. Corecursive t f ⇒ Coalgebra f a → a → t
+ana :: forall t f a. Corecursive t f => Coalgebra f a -> a -> t
 ana f = go
   where
   go a = embed (go <$> f a)
 
 anaM
-  ∷ ∀ t f m a
-  . Corecursive t f
-  ⇒ Monad m
-  ⇒ Traversable f
-  ⇒ CoalgebraM m f a
-  → a
-  → m t
+  :: forall t f m a
+   . Corecursive t f
+  => Monad m
+  => Traversable f
+  => CoalgebraM m f a
+  -> a
+  -> m t
 anaM f = go
   where
   go a = f a >>= (map embed <<< traverse go)
 
 gana
-  ∷ ∀ t f n a
-  . Corecursive t f
-  ⇒ Monad n
-  ⇒ DistributiveLaw n f
-  → GCoalgebra n f a
-  → a
-  → t
+  :: forall t f n a
+   . Corecursive t f
+  => Monad n
+  => DistributiveLaw n f
+  -> GCoalgebra n f a
+  -> a
+  -> t
 gana k f = go <<< pure <<< f
   where
   go a = embed $ map (go <<< map f <<< join) (k a)
 
 ganaM
-  ∷ ∀ t f m n a
-  . Corecursive t f
-  ⇒ Monad m
-  ⇒ Monad n
-  ⇒ Traversable f
-  ⇒ Traversable n
-  ⇒ DistributiveLaw n f
-  → GCoalgebraM n m f a
-  → a
-  → m t
+  :: forall t f m n a
+   . Corecursive t f
+  => Monad m
+  => Monad n
+  => Traversable f
+  => Traversable n
+  => DistributiveLaw n f
+  -> GCoalgebraM n m f a
+  -> a
+  -> m t
 ganaM k f = go <=< map pure <<< f
   where
   go a = embed <$> traverse (go <=< traverse f <<< join) (k a)
 
 elgotAna
-  ∷ ∀ t f n a
-  . Corecursive t f
-  ⇒ Monad n
-  ⇒ DistributiveLaw n f
-  → ElgotCoalgebra n f a
-  → a
-  → t
+  :: forall t f n a
+   . Corecursive t f
+  => Monad n
+  => DistributiveLaw n f
+  -> ElgotCoalgebra n f a
+  -> a
+  -> t
 elgotAna k f = go <<< f
   where
   go a = embed $ (go <<< (f =<< _)) <$> k a
 
 transAna
-  ∷ ∀ t f u g
-  . Recursive t f
-  ⇒ Corecursive u g
-  ⇒ Transform t f g
-  → t
-  → u
+  :: forall t f u g
+   . Recursive t f
+  => Corecursive u g
+  => Transform t f g
+  -> t
+  -> u
 transAna f = go
   where
   go t = mapR (map go <<< f) t
 
-transAnaT ∷ ∀ t f. Recursive t f ⇒ Corecursive t f ⇒ (t → t) → t → t
+transAnaT :: forall t f. Recursive t f => Corecursive t f => (t -> t) -> t -> t
 transAnaT f = go
   where
   go t = mapR (map go) (f t)
 
 transAnaM
-  ∷ ∀ t f u g m
-  . Recursive t f
-  ⇒ Corecursive u g
-  ⇒ Monad m
-  ⇒ Traversable g
-  ⇒ TransformM m t f g
-  → t
-  → m u
+  :: forall t f u g m
+   . Recursive t f
+  => Corecursive u g
+  => Monad m
+  => Traversable g
+  => TransformM m t f g
+  -> t
+  -> m u
 transAnaM f = go
   where
   go t = traverseR (traverse go <=< f) t
 
 transAnaTM
-  ∷ ∀ t f m
-  . Recursive t f
-  ⇒ Corecursive t f
-  ⇒ Monad m
-  ⇒ Traversable f
-  ⇒ Coalgebra m t
-  → t
-  → m t
+  :: forall t f m
+   . Recursive t f
+  => Corecursive t f
+  => Monad m
+  => Traversable f
+  => Coalgebra m t
+  -> t
+  -> m t
 transAnaTM f = go
   where
   go t = traverseR (traverse go) =<< f t
 
 postpro
-  ∷ ∀ t f a
-  . Recursive t f
-  ⇒ Corecursive t f
-  ⇒ (f ~> f)
-  → Coalgebra f a
-  → a
-  → t
+  :: forall t f a
+   . Recursive t f
+  => Corecursive t f
+  => (f ~> f)
+  -> Coalgebra f a
+  -> a
+  -> t
 postpro f g = gpostpro distAna f (map Identity <<< g)
 
 gpostpro
-  ∷ ∀ t f n a
-  . Recursive t f
-  ⇒ Corecursive t f
-  ⇒ Monad n
-  ⇒ DistributiveLaw n f
-  → (f ~> f)
-  → GCoalgebra n f a
-  → a
-  → t
+  :: forall t f n a
+   . Recursive t f
+  => Corecursive t f
+  => Monad n
+  => DistributiveLaw n f
+  -> (f ~> f)
+  -> GCoalgebra n f a
+  -> a
+  -> t
 gpostpro f g h = go <<< pure
   where
   go na = embed $ (ana (g <<< project) <<< go <<< join) <$> f (h <$> na)
 
 transPostpro
-  ∷ ∀ t f u g
-  . Recursive t f
-  ⇒ Recursive u g
-  ⇒ Corecursive u g
-  ⇒ (g ~> g)
-  → Transform t f g
-  → t
-  → u
+  :: forall t f u g
+   . Recursive t f
+  => Recursive u g
+  => Corecursive u g
+  => (g ~> g)
+  -> Transform t f g
+  -> t
+  -> u
 transPostpro f g = go
   where
   go t = mapR (map (transAna f <<< go) <<< g) t
 
-apo ∷ ∀ t f a. Corecursive t f ⇒ GCoalgebra (Either t) f a → a → t
+apo :: forall t f a. Corecursive t f => GCoalgebra (Either t) f a -> a -> t
 apo f = go
   where
   go a = embed $ either identity go <$> f a
 
 gapo
-  ∷ ∀ t f a b
-  . Corecursive t f
-  ⇒ Coalgebra f b
-  → GCoalgebra (Either b) f a
-  → a
-  → t
+  :: forall t f a b
+   . Corecursive t f
+  => Coalgebra f b
+  -> GCoalgebra (Either b) f a
+  -> a
+  -> t
 gapo f g = go
   where
   go a = embed $ either anaf go <$> g a
   anaf = ana f
 
 apoM
-  ∷ ∀ t f m a
-  . Corecursive t f
-  ⇒ Monad m
-  ⇒ Traversable f
-  ⇒ GCoalgebraM (Either t) m f a
-  → a
-  → m t
+  :: forall t f m a
+   . Corecursive t f
+  => Monad m
+  => Traversable f
+  => GCoalgebraM (Either t) m f a
+  -> a
+  -> m t
 apoM f = go
   where
   go a = embed <$> (traverse (either pure go) =<< f a)
 
-elgotApo ∷ ∀ t f a. Corecursive t f ⇒ ElgotCoalgebra (Either t) f a → a → t
+elgotApo :: forall t f a. Corecursive t f => ElgotCoalgebra (Either t) f a -> a -> t
 elgotApo f = go
   where
   go a = either identity (embed <<< map go) $ f a
 
 transApo
-  ∷ ∀ t f u g
-  . Recursive t f
-  ⇒ Corecursive u g
-  ⇒ CoalgebraicGTransform (Either u) t f g
-  → t
-  → u
+  :: forall t f u g
+   . Recursive t f
+  => Corecursive u g
+  => CoalgebraicGTransform (Either u) t f g
+  -> t
+  -> u
 transApo f = go
   where
   go t = mapR (map (either identity go) <<< f) t
 
 transApoT
-  ∷ ∀ t f
-  . Recursive t f
-  ⇒ Corecursive t f
-  ⇒ (t → Either t t)
-  → t
-  → t
+  :: forall t f
+   . Recursive t f
+  => Corecursive t f
+  => (t -> Either t t)
+  -> t
+  -> t
 transApoT f = go
   where
   go t = either identity (mapR (map go)) $ f t
 
-futu ∷ ∀ t f a. Corecursive t f ⇒ GCoalgebra (Free f) f a → a → t
+futu :: forall t f a. Corecursive t f => GCoalgebra (Free f) f a -> a -> t
 futu = gana distFutu
 
-elgotFutu ∷ ∀ t f a. Corecursive t f ⇒ ElgotCoalgebra (Free f) f a → a → t
+elgotFutu :: forall t f a. Corecursive t f => ElgotCoalgebra (Free f) f a -> a -> t
 elgotFutu = elgotAna distFutu
 
 futuM
-  ∷ ∀ t f m a
-  . Corecursive t f
-  ⇒ Monad m
-  ⇒ Traversable f
-  ⇒ GCoalgebraM (Free f) m f a
-  → a
-  → m t
+  :: forall t f m a
+   . Corecursive t f
+  => Monad m
+  => Traversable f
+  => GCoalgebraM (Free f) m f a
+  -> a
+  -> m t
 futuM f = go
   where
   go a = map embed <<< traverse loop =<< f a
   loop x = either (map embed <<< traverse loop) go (resume x)
 
-colambek ∷ ∀ t f. Recursive t f ⇒ Corecursive t f ⇒ f t → t
+colambek :: forall t f. Recursive t f => Corecursive t f => f t -> t
 colambek = ana (map project)

--- a/src/Matryoshka/Util.purs
+++ b/src/Matryoshka/Util.purs
@@ -21,15 +21,15 @@ import Prelude
 import Matryoshka.Class.Corecursive (class Corecursive, embed)
 import Matryoshka.Class.Recursive (class Recursive, project)
 
-mapR ∷ ∀ t f u g. Recursive t f ⇒ Corecursive u g ⇒ (f t → g u) → t → u
+mapR :: forall t f u g. Recursive t f => Corecursive u g => (f t -> g u) -> t -> u
 mapR f = embed <<< f <<< project
 
 traverseR
-  ∷ ∀ t f u g m
-  . Recursive t f
-  ⇒ Corecursive u g
-  ⇒ Functor m
-  ⇒ (f t → m (g u))
-  → t
-  → m u
+  :: forall t f u g m
+   . Recursive t f
+  => Corecursive u g
+  => Functor m
+  => (f t -> m (g u))
+  -> t
+  -> m u
 traverseR f = map embed <<< f <<< project

--- a/test/Test/Example/List.purs
+++ b/test/Test/Example/List.purs
@@ -28,8 +28,9 @@ prod Nil = 1
 prod (Cons h t) = h * t
 
 count :: Coalgebra (ListF Int) Int
-count n | n <= 0    = Nil
-        | otherwise = Cons n (n - 1)
+count n
+  | n <= 0 = Nil
+  | otherwise = Cons n (n - 1)
 
 fac :: Int -> Int
 fac = hylo prod count


### PR DESCRIPTION

**Description of the change**
Introduces the [`purs-tidy`](https://github.com/natefaubion/purescript-tidy) formatter. This formatter is a lightly opinionated tool we use to maintain a consistent style in the contrib libraries.

We ordinarily restrict to tools provided by the `core` or `contrib` projects. This tool is not, but it was developed and is maintained by core team members, and because it's a formatter it can't block maintenance or release of this library even in the event something goes catastrophically wrong with it.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
